### PR TITLE
Better fix for "corrupted notes" by fetching individual fields if `properties()` fails

### DIFF
--- a/Workflow/get-data
+++ b/Workflow/get-data
@@ -16,18 +16,28 @@ const sfItems = Application("Notes").folders().flatMap(folderReference => {
 
   if (ignoredFolders.find(ignoredFolder => ignoredFolder === folderName)) return []
 
-  return folderReference.notes().map(note => {
+  return folderReference.notes().map(noteReference => {
     try {
+      const note = noteReference.properties()
+
       return {
-        uid: note.id(),
-        title: note.passwordProtected() ? "🔒" + note.name() : note.name(),
+        uid: note.id,
+        title: note.passwordProtected ? "🔒" + note.name : note.name,
         subtitle: folderName,
-        arg: note.id(),
-        match: folderName + " " + note.name() + " " + note.plaintext()
+        arg: note.id,
+        match: folderName + " " + note.name + " " + note.plaintext
       }
     } catch (error) {
-      console.log(`Error #${error.errorNumber}: ${error.message} at line ${error.line} column ${error.column}`);
-      throw `Corrupted note: ${note.name()}. Try editing it and replacing images.`
+      console.log(`Error #${error.errorNumber}: ${error.message} at line ${error.line} column ${error.column}`)
+      console.log(`Using slower, direct field access on note named: "${noteReference.name()}"`)
+
+      return {
+        uid: noteReference.id(),
+        title: noteReference.passwordProtected() ? "🔒" + noteReference.name() : noteReference.name(),
+        subtitle: folderName,
+        arg: noteReference.id(),
+        match: folderName + " " + noteReference.name() + " " + noteReference.plaintext()
+      }
     }
   })
 })

--- a/Workflow/get-data
+++ b/Workflow/get-data
@@ -16,19 +16,17 @@ const sfItems = Application("Notes").folders().flatMap(folderReference => {
 
   if (ignoredFolders.find(ignoredFolder => ignoredFolder === folderName)) return []
 
-  return folderReference.notes().map(noteReference => {
+  return folderReference.notes().map(note => {
     try {
-      const note = noteReference.properties()
-
       return {
-        uid: note.id,
-        title: note.passwordProtected ? "🔒" + note.name : note.name,
+        uid: note.id(),
+        title: note.passwordProtected() ? "🔒" + note.name() : note.name(),
         subtitle: folderName,
-        arg: note.id,
-        match: folderName + " " + note.name + " " + note.plaintext
+        arg: note.id(),
+        match: folderName + " " + note.name() + " " + note.plaintext()
       }
     } catch {
-      throw `Corrupted note: ${noteReference.name()}. Try editing it and replacing images.`
+      throw `Corrupted note: ${note.name()}. Try editing it and replacing images.`
     }
   })
 })

--- a/Workflow/get-data
+++ b/Workflow/get-data
@@ -25,7 +25,8 @@ const sfItems = Application("Notes").folders().flatMap(folderReference => {
         arg: note.id(),
         match: folderName + " " + note.name() + " " + note.plaintext()
       }
-    } catch {
+    } catch (error) {
+      console.log(`Error #${error.errorNumber}: ${error.message} at line ${error.line} column ${error.column}`);
       throw `Corrupted note: ${note.name()}. Try editing it and replacing images.`
     }
   })

--- a/Workflow/info.plist
+++ b/Workflow/info.plist
@@ -450,7 +450,7 @@ function show_data {
 }
 
 # Get latest state
-readonly state="$(osascript -l JavaScript -e 'Application("Notes").notes[0].properties()' || uuidgen)"
+readonly state="$(osascript -l JavaScript -e 'const note = Application("Notes").notes[0]; [note.id(), note.modificationDate().toJSON() ]' || uuidgen)"
 
 # Exit early if state has not changed
 [[ "${state}" == "$(&lt; "${state_file}")" ]] &amp;&amp; show_data


### PR DESCRIPTION
Edit: Keep the fast `properties()` call for most notes, but in the `catch` block, fall back to the older, slower method of fetching note fields, instead of telling the user to delete their note.

~~Avoid calling `properties()`, instead fetch only the needed Note fields.~~

Fixes the `Corrupted note:` error for me from #3. Poking around in the safari inspector, it looks like calling `noteReference.properties()` will (maybe only sometimes?) convert attachments into `data:image/jpeg;base64` and embed the image data inline into the `body` HTML property (!!). I suspect, based on [this comment](https://github.com/alfredapp/notes-workflow/issues/3#issuecomment-3173383801) that is related to the failure of some notes.

Doing it this way lets the workflow script work on all of my notes without any changes. It logs 3 notes that would have failed.

This PR also changes the state file to use only latest note's `id` and  `modificationDate`, instead of the full `properties()`. This is important if the latest note is one that fails on calls for `properties()`. I think these two fields are sufficient for cache invalidation.

Also, added a log message in the `catch` block with the error details. I found it useful, and suspect it'll help with any future errors, so I left it in.
